### PR TITLE
Rework bitmap handling

### DIFF
--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -61,7 +61,7 @@ namespace fs = std::filesystem;
 
 
 Parser::Parser(const fs::path& aFile, FileFormatVersion aFileFormatVersion) :
-    mFileFormatVersion{aFileFormatVersion}, mFileCtr{0u}, mFileErrCtr{0u}
+    mFileFormatVersion{aFileFormatVersion}, mFileCtr{0U}, mFileErrCtr{0U}, mImgCtr{0U}
 {
     mFileType      = getFileTypeByExtension(aFile);
     mInputFile     = aFile;
@@ -1039,6 +1039,8 @@ void Parser::openFile(const fs::path& aFile)
     }
 
     mRemainingFiles.erase(it);
+
+    mImgCtr = 0U;
 
     mDs = DataStream{aFile};
     if(!mDs)

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -1105,10 +1105,15 @@ void Parser::sanitizeThisFutureSize(std::optional<FutureData> aThisFuture)
         {
             const std::string msg = fmt::format("{}: StopOffsets differ! 0x{:08x} (expected) vs. 0x{:08x} (actual)",
                 __func__, aThisFuture.value().getStopOffset(), stopOffset);
+
             spdlog::error(msg);
             spdlog::critical("The structure may have changed due to version differences!");
             throw std::runtime_error(msg);
         }
+    }
+    else
+    {
+        spdlog::debug("{}: Could not verify structure size as future is not available.", __func__);
     }
 }
 

--- a/src/Parser.hpp
+++ b/src/Parser.hpp
@@ -279,7 +279,7 @@ private:
 
     fs::path mExtractedPath;
 
-    size_t mFileCtr;    //!< Counts all files that were opend for parsing
+    size_t mFileCtr;    //!< Counts all files that were opened for parsing
     size_t mFileErrCtr; //!< Counts all files that failed somewhere
 
     DataStream mDs;
@@ -287,6 +287,8 @@ private:
     uint32_t mByteOffset;
 
     FutureDataLst mFutureDataLst;
+
+    size_t mImgCtr; //!< Counts images per stream
 };
 
 

--- a/src/Primitives/PrimBitmap.cpp
+++ b/src/Primitives/PrimBitmap.cpp
@@ -1,35 +1,21 @@
 #include <cstdint>
+#include <filesystem>
 #include <iostream>
 #include <ostream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
+#include <fmt/core.h>
 #include <nameof.hpp>
+#include <spdlog/spdlog.h>
 
 #include "General.hpp"
 #include "Parser.hpp"
 #include "Primitives/PrimBitmap.hpp"
 
 
-// @todo Add additional header info such that the bitmap can be opened with a standard
-//       image viewer.
-void PrimBitmap::writeBmpToFile(const std::string& aFilePath) const
-{
-    std::ofstream bmp{aFilePath, std::ios::out | std::ios::binary};
-
-    if(!bmp)
-    {
-        spdlog::error("Cannot open file for writing! {}", aFilePath);
-        exit(1);
-    }
-
-    for(const auto& data : rawImgData)
-    {
-        bmp.write(reinterpret_cast<const char*>(&data), sizeof(data));
-    }
-
-    bmp.close();
-}
+namespace fs = std::filesystem;
 
 
 PrimBitmap Parser::readPrimBitmap()
@@ -47,31 +33,65 @@ PrimBitmap Parser::readPrimBitmap()
     obj.locX = mDs.readInt32();
     obj.locY = mDs.readInt32();
 
+    spdlog::debug("locX = {}", obj.locX);
+    spdlog::debug("locY = {}", obj.locY);
+
     obj.x2 = mDs.readInt32();
     obj.y2 = mDs.readInt32();
     obj.x1 = mDs.readInt32();
     obj.y1 = mDs.readInt32();
 
+    spdlog::debug("x2 = {}", obj.x2);
+    spdlog::debug("y2 = {}", obj.y2);
+    spdlog::debug("x1 = {}", obj.x1);
+    spdlog::debug("y1 = {}", obj.y1);
+
     obj.bmpWidth  = mDs.readUint32();
     obj.bmpHeight = mDs.readUint32();
 
-    const uint32_t imgSize = mDs.readUint32();
+    spdlog::debug("bmpWidth  = {}", obj.bmpWidth);
+    spdlog::debug("bmpHeight = {}", obj.bmpHeight);
+
+    const uint32_t dataSize = mDs.readUint32();
+
+    spdlog::debug("dataSize = {}", dataSize);
+
+    // Offset from the beginning of the image header to the actual image data
+    const uint32_t offset = 40U;
+
+    const uint32_t colorChannels = 3U; // Red, Green and Blue are always used
+
+    if(dataSize != offset + obj.bmpWidth * obj.bmpHeight * colorChannels)
+    {
+        const std::string msg = fmt::format("{}: Unexpected bitmap data size of {} Byte!", __func__, dataSize);
+
+        spdlog::error(msg);
+        throw std::runtime_error(msg);
+    }
 
     obj.rawImgData.clear();
+    obj.rawImgData.reserve(dataSize);
 
-    for(size_t i = 0u; i < imgSize; ++i)
+    for(size_t i = 0U; i < dataSize; ++i)
     {
         obj.rawImgData.push_back(mDs.readUint8());
     }
 
-    // obj.writeBmpToFile("foo" + std::to_string(imgSize) + ".bmp"); // @todo Require useful name
+    const fs::path filename = mCurrOpenFile.parent_path() / fmt::format("{}_img_{}.bmp",
+        mCurrOpenFile.stem().string(), mImgCtr);
+
+    spdlog::info("{}: Writing bitmap file to {}", __func__, filename.string());
+
+    obj.writeBmpToFile(filename);
+
+    ++mImgCtr;
 
     if(mDs.getCurrentOffset() != startOffset + byteLength)
     {
         throw MisinterpretedData(__func__, startOffset, byteLength, mDs.getCurrentOffset());
     }
 
-    if(byteLength != 44u + imgSize)
+    if(byteLength != 44U + dataSize)
     {
         throw FileFormatChanged("Bitmap");
     }
@@ -80,4 +100,49 @@ PrimBitmap Parser::readPrimBitmap()
     spdlog::info(to_string(obj));
 
     return obj;
+}
+
+
+void PrimBitmap::writeBmpToFile(const fs::path& aFilePath) const
+{
+    std::ofstream bmp{aFilePath, std::ios::out | std::ios::binary};
+
+    if(!bmp)
+    {
+        const std::string msg = fmt::format("{}: Can not open file for writing: {}",
+            __func__, aFilePath.string());
+
+        spdlog::error(msg);
+        throw std::runtime_error(msg);
+    }
+
+    // Reconstruct header information that was not stored in the file container
+    // See https://en.wikipedia.org/wiki/BMP_file_format#Bitmap_file_header
+    // for further details on the meaning of each configuration value.
+    struct BmpHeader
+    {
+        uint16_t magicBytes = 0x4d42;
+        uint32_t bmpSize    =  0; // Will be set later
+        uint32_t reserved   =  0;
+        uint32_t offset     = 54; // @note Maybe this offset needs to be adjusted according to the bitmap
+    } header;
+
+    // @note We can not derive the header size automatically as the compiler
+    //       inserts additional space into the structure for better alignment
+    const uint32_t headerSize = 14U; // Size in Byte
+
+    header.bmpSize = rawImgData.size() + headerSize;
+
+    // Start writing the file
+    bmp.write(reinterpret_cast<const char*>(&header.magicBytes), sizeof(header.magicBytes));
+    bmp.write(reinterpret_cast<const char*>(&header.bmpSize), sizeof(header.bmpSize));
+    bmp.write(reinterpret_cast<const char*>(&header.reserved), sizeof(header.reserved));
+    bmp.write(reinterpret_cast<const char*>(&header.offset), sizeof(header.offset));
+
+    for(const auto& data : rawImgData)
+    {
+        bmp.write(reinterpret_cast<const char*>(&data), sizeof(data));
+    }
+
+    bmp.close();
 }

--- a/src/Primitives/PrimBitmap.hpp
+++ b/src/Primitives/PrimBitmap.hpp
@@ -18,7 +18,7 @@ namespace fs = std::filesystem;
 
 struct PrimBitmap
 {
-    void writeBmpToFile(const fs::path& aFilePath) const;
+    fs::path writeImgToFile(fs::path aFilePath) const;
 
     int32_t locX;
     int32_t locY;

--- a/src/Primitives/PrimBitmap.hpp
+++ b/src/Primitives/PrimBitmap.hpp
@@ -3,6 +3,7 @@
 
 
 #include <cstdint>
+#include <filesystem>
 #include <ostream>
 #include <string>
 
@@ -12,9 +13,12 @@
 #include "General.hpp"
 
 
+namespace fs = std::filesystem;
+
+
 struct PrimBitmap
 {
-    void writeBmpToFile(const std::string& aFilePath) const;
+    void writeBmpToFile(const fs::path& aFilePath) const;
 
     int32_t locX;
     int32_t locY;
@@ -27,8 +31,6 @@ struct PrimBitmap
     uint32_t bmpWidth;
     uint32_t bmpHeight;
 
-    // @todo Add better Bitmap support and figure out how to
-    //       create a *.bmp file out of the rawImgData
     // @note Looks like the XSD uses Base64 encoding for the data, but I was not
     //       able to extract the correct content from there. Are there some parameters
     //       to adjust in the decoding? https://cryptii.com/pipes/base64-to-binary
@@ -51,7 +53,7 @@ static std::string to_string(const PrimBitmap& aObj)
     str += fmt::format("{}bmpWidth  = {}\n", indent(1), aObj.bmpWidth);
     str += fmt::format("{}bmpHeight = {}\n", indent(1), aObj.bmpHeight);
 
-    // @todo Should we print rawImgData somehow?
+    // @todo Should we print rawImgData somehow? As ASCII image?
 
     return str;
 }

--- a/src/Structures/StructSymbolPinScalar.hpp
+++ b/src/Structures/StructSymbolPinScalar.hpp
@@ -36,9 +36,6 @@ static std::string to_string(const StructSymbolPinScalar& aObj)
 
     str += fmt::format("{}:\n", nameof::nameof_type<decltype(aObj)>());
     str += fmt::format("{}name     = {}\n", indent(1), aObj.name);
-
-    str += fmt::format("{}startX   = {}\n", indent(1), aObj.startX);
-
     str += fmt::format("{}startX   = {}\n", indent(1), aObj.startX);
     str += fmt::format("{}startY   = {}\n", indent(1), aObj.startY);
     str += fmt::format("{}hotptX   = {}\n", indent(1), aObj.hotptX);


### PR DESCRIPTION
Implemented export for Bitmap files.

Tested with `ROHMUSDC/BD9E151NUX-EVK-101/Design Files/Schematic_BOM/BD9E151NUX-E2EVK-101_SCH_REV00_2014-08-19_1800.DSN` where the title block image was extracted from the `Cache` stream.

`test/designs/JerryZheng89/PCB_lib/OrCAD/MIKE_SCH_MIX.OLB` provides a few different files like BMP, JPG, and PNG.