### PR TITLE
Move prefix parsing into each object

### DIFF
--- a/src/Misc.cpp
+++ b/src/Misc.cpp
@@ -163,10 +163,6 @@ StructPrimitives Parser::readStructGlobalSymbol()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
-    auto_read_prefixes();
-
-    readPreamble();
-
     const std::optional<FutureData> thisFuture = getFutureData();
 
     StructPrimitives obj = readStructPrimitives();

--- a/src/Misc.cpp
+++ b/src/Misc.cpp
@@ -201,10 +201,6 @@ StructPrimitives Parser::readStructOffPageSymbol()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
-    auto_read_prefixes();
-
-    readPreamble();
-
     const std::optional<FutureData> thisFuture = getFutureData();
 
     StructPrimitives obj = readStructPrimitives();

--- a/src/Misc.cpp
+++ b/src/Misc.cpp
@@ -147,8 +147,7 @@ void Parser::readTitleBlockSymbol()
 
     for(size_t i = 0u; i < followingLen; ++i)
     {
-        const Structure structure = auto_read_prefixes();
-        readStructure(structure);
+        readStructure();
     }
 
     if(!mDs.isEoF())
@@ -163,6 +162,8 @@ void Parser::readTitleBlockSymbol()
 StructPrimitives Parser::readStructGlobalSymbol()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
+
+    auto_read_prefixes();
 
     readPreamble();
 
@@ -185,6 +186,8 @@ StructPrimitives Parser::readStructHierarchicSymbol()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
+    auto_read_prefixes();
+
     readPreamble();
 
     const std::optional<FutureData> thisFuture = getFutureData();
@@ -205,6 +208,8 @@ StructPrimitives Parser::readStructHierarchicSymbol()
 StructPrimitives Parser::readStructOffPageSymbol()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
+
+    auto_read_prefixes();
 
     readPreamble();
 
@@ -229,6 +234,8 @@ StructPrimitives Parser::readStructPinShapeSymbol()
 
     readPreamble();
 
+    auto_read_prefixes();
+
     const std::optional<FutureData> thisFuture = getFutureData();
 
     StructPrimitives obj = readStructPrimitives();
@@ -252,9 +259,7 @@ bool Parser::readStreamERC()
 
     bool obj = false;
 
-    Structure structure = auto_read_prefixes();
-
-    readStructure(structure); // @todo push structure
+    readStructure(); // @todo push structure
 
     if(!mDs.isEoF())
     {

--- a/src/Misc.cpp
+++ b/src/Misc.cpp
@@ -220,10 +220,6 @@ StructPrimitives Parser::readStructPinShapeSymbol()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
-    readPreamble();
-
-    auto_read_prefixes();
-
     const std::optional<FutureData> thisFuture = getFutureData();
 
     StructPrimitives obj = readStructPrimitives();

--- a/src/Misc.cpp
+++ b/src/Misc.cpp
@@ -182,10 +182,6 @@ StructPrimitives Parser::readStructHierarchicSymbol()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
-    auto_read_prefixes();
-
-    readPreamble();
-
     const std::optional<FutureData> thisFuture = getFutureData();
 
     StructPrimitives obj = readStructPrimitives();

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -648,6 +648,12 @@ Structure Parser::auto_read_prefixes()
     spdlog::info("{}: Found {} prefixes\n", __func__, prefixCtr);
     Structure structure = read_prefixes(prefixCtr);
 
+    // @todo Looks like each structure type has a fixed number of prefixes
+    //       I.e. figure out the numbers for each structure and move the
+    //       parsing code into the structure specific parser. This should
+    //       get rid of auto_read_prefixes.
+    spdlog::info("Prefixes: {} = {}", to_string(structure), prefixCtr);
+
     mDs.sanitizeNoEoF();
 
     return structure;
@@ -848,6 +854,20 @@ void Parser::readPreamble()
 }
 
 
+VariantPrimitive Parser::readPrimitive()
+{
+    spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
+
+    Primitive typeId = ToPrimitive(mDs.peek(1)[0]);
+
+    VariantPrimitive retStruct = readPrimitive(typeId);
+
+    spdlog::debug(getClosingMsg(__func__, mDs.getCurrentOffset()));
+
+    return retStruct;
+}
+
+
 VariantPrimitive Parser::readPrimitive(Primitive aPrimitive)
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
@@ -878,6 +898,20 @@ VariantPrimitive Parser::readPrimitive(Primitive aPrimitive)
     spdlog::debug(getClosingMsg(__func__, mDs.getCurrentOffset()));
 
     return retPrim;
+}
+
+
+VariantStructure Parser::readStructure()
+{
+    spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
+
+    Structure typeId = ToStructure(mDs.peek(1)[0]);
+
+    VariantStructure retStruct = readStructure(typeId);
+
+    spdlog::debug(getClosingMsg(__func__, mDs.getCurrentOffset()));
+
+    return retStruct;
 }
 
 

--- a/src/Parser.hpp
+++ b/src/Parser.hpp
@@ -248,8 +248,12 @@ public:
     Point readPoint();
     TextFont readTextFont();
 
+    VariantPrimitive readPrimitive();
     VariantPrimitive readPrimitive(Primitive aPrimitive);
+
+    VariantStructure readStructure();
     VariantStructure readStructure(Structure aStructure);
+
     TrailingProperties readTrailingProperties();
 
     void readTitleBlockSymbol();

--- a/src/Primitives/PrimSymbolVector.cpp
+++ b/src/Primitives/PrimSymbolVector.cpp
@@ -16,6 +16,8 @@ PrimSymbolVector Parser::readPrimSymbolVector()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
+    auto_read_prefixes();
+
     const std::optional<FutureData> thisFuture = getFutureData();
 
     PrimSymbolVector obj;
@@ -34,7 +36,8 @@ PrimSymbolVector Parser::readPrimSymbolVector()
 
     // @todo Figure out the size
     //       Probably it's always 20 Byte, try this first
-    discard_until_preamble();
+    // discard_until_preamble();
+
     readPreamble();
 
     obj.locX = mDs.readInt16();

--- a/src/Streams/StreamPackage.cpp
+++ b/src/Streams/StreamPackage.cpp
@@ -68,16 +68,13 @@ StreamPackage Parser::readStreamPackage(FileFormatVersion aVersion)
 
     StreamPackage obj;
 
-    Structure structure;
-
     const uint16_t sectionCount = mDs.readUint16();
 
     spdlog::info("sectionCount = {}", sectionCount);
 
     for(size_t i = 0u; i < sectionCount; ++i)
     {
-        Structure structure = auto_read_prefixes();
-        obj.structures.push_back(readStructure(structure));
+        obj.structures.push_back(readStructure());
     }
 
     // @todo maybe number of views (Convert, Normal) or number of units in the current view
@@ -87,8 +84,7 @@ StreamPackage Parser::readStreamPackage(FileFormatVersion aVersion)
 
     for(size_t i = 0u; i < len2; ++i)
     {
-        Structure structure = auto_read_prefixes();
-        obj.structures.push_back(readStructure(structure));
+        obj.structures.push_back(readStructure());
     }
 
     // @todo Probably only StructSymbolPinScalar
@@ -98,8 +94,7 @@ StreamPackage Parser::readStreamPackage(FileFormatVersion aVersion)
 
     for(size_t i = 0u; i < len3; ++i)
     {
-        Structure structure = auto_read_prefixes();
-        obj.structures.push_back(readStructure(structure));
+        obj.structures.push_back(readStructure());
 
         const uint8_t early_out = mDs.peek(1)[0];
         spdlog::critical("early_out = {}", early_out);
@@ -118,13 +113,11 @@ StreamPackage Parser::readStreamPackage(FileFormatVersion aVersion)
 
     for(size_t i = 0u; i < len4; ++i)
     {
-        Structure structure = auto_read_prefixes();
-        obj.structures.push_back(readStructure(structure));
+        obj.structures.push_back(readStructure());
     }
 
     {
-        Structure structure = auto_read_prefixes();
-        obj.structures.push_back(readStructure(structure));
+        obj.structures.push_back(readStructure());
     }
 
     // I guess its always a PinIdxMapping (or multiple)
@@ -135,8 +128,7 @@ StreamPackage Parser::readStreamPackage(FileFormatVersion aVersion)
 
     for(size_t i = 0u; i < len5; ++i)
     {
-        Structure structure = auto_read_prefixes();
-        obj.structures.push_back(readStructure(structure));
+        obj.structures.push_back(readStructure());
     }
 
     if(!mDs.isEoF())

--- a/src/Streams/StreamPage.cpp
+++ b/src/Streams/StreamPage.cpp
@@ -152,8 +152,7 @@ bool Parser::readStreamPage()
 
     for(size_t i = 0u; i < len2; ++i)
     {
-        Structure structure = auto_read_prefixes();
-        readStructure(structure); // @todo push structure
+        readStructure(); // @todo push structure
     }
 
     const uint16_t len3 = mDs.readUint16();
@@ -162,20 +161,7 @@ bool Parser::readStreamPage()
 
     for(size_t i = 0u; i < len3; ++i)
     {
-        Structure structure;
-
-        if(i == 0u)
-        {
-            // @todo this is type_prefix_very_long()
-            mDs.printUnknownData(47, std::string(__func__) + " - 11");
-            structure = ToStructure(0x0d); // Parse package instance for now until type_prefix_very_long is implemented
-        }
-        else
-        {
-            structure = auto_read_prefixes();
-        }
-
-        readStructure(structure); // @todo push structure
+        readStructure(); // @todo push structure
     }
 
     mDs.printUnknownData(10, std::string(__func__) + " - 10");
@@ -186,8 +172,7 @@ bool Parser::readStreamPage()
 
     for(size_t i = 0u; i < lenX; ++i)
     {
-        Structure structure = auto_read_prefixes();
-        readStructure(structure); // @todo push structure
+        readStructure(); // @todo push structure
     }
 
     if(!mDs.isEoF())

--- a/src/Streams/StreamSymbol.cpp
+++ b/src/Streams/StreamSymbol.cpp
@@ -15,8 +15,7 @@ StreamSymbol Parser::readStreamSymbol()
 
     StreamSymbol obj;
 
-    Structure structure = auto_read_prefixes();
-    obj.structures.push_back(readStructure(structure));
+    obj.structures.push_back(readStructure());
 
     mDs.printUnknownData(4, fmt::format("{}: 0", __func__));
 
@@ -58,8 +57,7 @@ StreamSymbol Parser::readStreamSymbol()
 
     for(size_t i = 0u; i < len; ++i)
     {
-        Structure structure = auto_read_prefixes();
-        obj.structures.push_back(readStructure(structure));
+        obj.structures.push_back(readStructure());
     }
 
     const uint16_t len2 = mDs.readUint16();
@@ -68,8 +66,7 @@ StreamSymbol Parser::readStreamSymbol()
 
     for(size_t i = 0u; i < len2; ++i)
     {
-        Structure structure = auto_read_prefixes();
-        obj.structures.push_back(readStructure(structure));
+        obj.structures.push_back(readStructure());
     }
 
     if(!mDs.isEoF())

--- a/src/Structures/StructAlias.cpp
+++ b/src/Structures/StructAlias.cpp
@@ -13,6 +13,8 @@ StructAlias Parser::readStructAlias()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
+    auto_read_prefixes();
+
     readPreamble();
 
     const std::optional<FutureData> thisFuture = getFutureData();

--- a/src/Structures/StructERCSymbol.cpp
+++ b/src/Structures/StructERCSymbol.cpp
@@ -14,6 +14,8 @@ StructERCSymbol Parser::readStructERCSymbol()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
+    auto_read_prefixes();
+
     readPreamble();
 
     const std::optional<FutureData> thisFuture = getFutureData();

--- a/src/Structures/StructGraphicBoxInst.cpp
+++ b/src/Structures/StructGraphicBoxInst.cpp
@@ -14,6 +14,8 @@ StructGraphicBoxInst Parser::readStructGraphicBoxInst()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
+    auto_read_prefixes();
+
     readPreamble();
 
     const std::optional<FutureData> thisFuture = getFutureData();
@@ -40,9 +42,7 @@ StructGraphicBoxInst Parser::readStructGraphicBoxInst()
     // @todo Only Rect as a shape would make sense here. Maybe this should be passed
     //       as a parameter to readSthInPages0 to check this condition. Further,
     //       parseStructure should always call readSthInPages0.
-    // Structure structure = read_prefixes(4);
-    Structure structure = auto_read_prefixes();
-    readStructure(structure);
+    readStructure();
 
     sanitizeThisFutureSize(thisFuture);
 

--- a/src/Structures/StructGraphicCommentTextInst.cpp
+++ b/src/Structures/StructGraphicCommentTextInst.cpp
@@ -13,6 +13,8 @@ StructGraphicCommentTextInst Parser::readStructGraphicCommentTextInst()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
+    auto_read_prefixes();
+
     readPreamble();
 
     const std::optional<FutureData> thisFuture = getFutureData();

--- a/src/Structures/StructPartInst.cpp
+++ b/src/Structures/StructPartInst.cpp
@@ -16,6 +16,8 @@ StructPartInst Parser::readStructPartInst()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
+    auto_read_prefixes();
+
     readPreamble();
 
     const std::optional<FutureData> thisFuture = getFutureData();
@@ -41,8 +43,7 @@ StructPartInst Parser::readStructPartInst()
 
     for(size_t i = 0u; i < len; ++i)
     {
-        Structure structure = auto_read_prefixes();
-        readStructure(structure); // @todo push struct
+        readStructure(); // @todo push struct
     }
 
     mDs.printUnknownData(1, std::string(__func__) + " - 3");
@@ -55,8 +56,7 @@ StructPartInst Parser::readStructPartInst()
 
     for(size_t i = 0u; i < len2; ++i)
     {
-        Structure structure = auto_read_prefixes();
-        readStructure(structure); // @todo push struct
+        readStructure(); // @todo push struct
     }
 
     std::string sth1 = mDs.readStringLenZeroTerm(); // @todo needs verification

--- a/src/Structures/StructPinIdxMapping.cpp
+++ b/src/Structures/StructPinIdxMapping.cpp
@@ -15,6 +15,8 @@ StructPinIdxMapping Parser::readStructPinIdxMapping()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
+    auto_read_prefixes();
+
     readPreamble();
 
     const std::optional<FutureData> thisFuture = getFutureData();

--- a/src/Structures/StructPrimitives.cpp
+++ b/src/Structures/StructPrimitives.cpp
@@ -65,6 +65,8 @@ StructPrimitives Parser::readStructPrimitives(FileFormatVersion aVersion)
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
+    auto_read_prefixes();
+
     readPreamble();
 
     const std::optional<FutureData> thisFuture = getFutureData();

--- a/src/Structures/StructProperties.cpp
+++ b/src/Structures/StructProperties.cpp
@@ -16,6 +16,8 @@ StructProperties Parser::readStructProperties()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
+    auto_read_prefixes();
+
     readPreamble();
 
     const std::optional<FutureData> thisFuture = getFutureData();

--- a/src/Structures/StructSthInPages0.cpp
+++ b/src/Structures/StructSthInPages0.cpp
@@ -17,6 +17,8 @@ StructSthInPages0 Parser::readStructSthInPages0()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
+    auto_read_prefixes();
+
     readPreamble();
 
     const std::optional<FutureData> thisFuture = getFutureData();

--- a/src/Structures/StructSymbolDisplayProp.cpp
+++ b/src/Structures/StructSymbolDisplayProp.cpp
@@ -13,6 +13,8 @@ StructSymbolDisplayProp Parser::readStructSymbolDisplayProp()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
+    auto_read_prefixes();
+
     readPreamble();
 
     const std::optional<FutureData> thisFuture = getFutureData();

--- a/src/Structures/StructSymbolPinBus.cpp
+++ b/src/Structures/StructSymbolPinBus.cpp
@@ -16,6 +16,8 @@ StructSymbolPinBus Parser::readStructSymbolPinBus()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
+    auto_read_prefixes();
+
     readPreamble();
 
     const std::optional<FutureData> thisFuture = getFutureData();

--- a/src/Structures/StructSymbolPinScalar.cpp
+++ b/src/Structures/StructSymbolPinScalar.cpp
@@ -16,6 +16,8 @@ StructSymbolPinScalar Parser::readStructSymbolPinScalar()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
+    auto_read_prefixes();
+
     readPreamble();
 
     const std::optional<FutureData> thisFuture = getFutureData();
@@ -41,17 +43,7 @@ StructSymbolPinScalar Parser::readStructSymbolPinScalar()
 
     for(size_t i = 0U; i < struct_len; ++i)
     {
-        const Structure structure = auto_read_prefixes();
-
-        if(structure != Structure::SymbolDisplayProp)
-        {
-            const std::string msg = fmt::format("{}: Expected {} but got {}",
-                __func__, to_string(Structure::SymbolDisplayProp), to_string(structure));
-
-            spdlog::error(msg);
-        }
-
-        readStructure(structure);
+        readStructure();
     }
 
     sanitizeThisFutureSize(thisFuture);

--- a/src/Structures/StructT0x10.cpp
+++ b/src/Structures/StructT0x10.cpp
@@ -13,6 +13,8 @@ StructT0x10 Parser::readStructT0x10()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
+    auto_read_prefixes();
+
     readPreamble();
 
     const std::optional<FutureData> thisFuture = getFutureData();

--- a/src/Structures/StructT0x1f.cpp
+++ b/src/Structures/StructT0x1f.cpp
@@ -16,6 +16,8 @@ StructT0x1f Parser::readStructT0x1f()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
+    auto_read_prefixes();
+
     readPreamble();
 
     const std::optional<FutureData> thisFuture = getFutureData();

--- a/src/Structures/StructWireScalar.cpp
+++ b/src/Structures/StructWireScalar.cpp
@@ -15,6 +15,8 @@ StructWireScalar Parser::readStructWireScalar()
 {
     spdlog::debug(getOpeningMsg(__func__, mDs.getCurrentOffset()));
 
+    auto_read_prefixes();
+
     readPreamble();
 
     const std::optional<FutureData> thisFuture = getFutureData();
@@ -56,8 +58,7 @@ StructWireScalar Parser::readStructWireScalar()
         for(size_t i = 0u; i < len; ++i)
         {
             // @todo len should always be 1 and the read structure should be 'Alias'
-            Structure structure = auto_read_prefixes();
-            readStructure(structure); // @todo push
+            readStructure(); // @todo push
         }
     }
 


### PR DESCRIPTION
It seems like each object has a constant number of prefixes, this is the first step to adapt this behavior.