### PR TITLE
Increase valid string size

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -1314,7 +1314,7 @@ repositories:
   - errors: 3
     options: null
     path: ./orcad capture/unsorted/_archive/pspice/abm.olb
-  - errors: 196
+  - errors: 34
     options: null
     path: ./orcad capture/unsorted/_archive/pspice/ad_reg.olb
   - errors: 0
@@ -1824,7 +1824,7 @@ repositories:
   - errors: 0
     options: null
     path: ./orcad capture/unsorted/_archive/pspice/thyristr.olb
-  - errors: 73
+  - errors: 0
     options: null
     path: ./orcad capture/unsorted/_archive/pspice/tline.olb
   - errors: 0

--- a/src/DataStream.cpp
+++ b/src/DataStream.cpp
@@ -34,7 +34,7 @@ std::string DataStream::readStringZeroTerm()
 {
     std::string str;
 
-    const size_t max_chars = 800u;
+    const size_t max_chars = 2500u;
 
     for(size_t i = 0u; i < max_chars; ++i)
     {


### PR DESCRIPTION
`test/designs/jmerdich/allegro-library/orcad capture/unsorted/_archive/pspice/ad_reg.olb` has PSpice definition of 2099 characters