### PR TITLE
Add more structures to parent

### DIFF
--- a/src/CommonBase.cpp
+++ b/src/CommonBase.cpp
@@ -425,7 +425,7 @@ void CommonBase::sanitizeThisFutureSize(std::optional<FutureData> aThisFuture)
                 __func__, aThisFuture.value().getStopOffset(), stopOffset);
 
             spdlog::error(msg);
-            spdlog::critical("The structure may have changed due to version differences!");
+            spdlog::warn("The structure may have changed due to version differences!");
             throw std::runtime_error(msg);
         }
     }

--- a/src/FutureData.hpp
+++ b/src/FutureData.hpp
@@ -26,15 +26,15 @@ public:
 
         if(aAbsStartPreambleOffset <= aAbsStopPreambleOffset)
         {
-            spdlog::error("{}: StopPreamble always appears before the StartPreamble!", __func__);
+            spdlog::warn("{}: StopPreamble always appears before the StartPreamble!", __func__);
         }
 
         mAbsStartOffset = aAbsStartPreambleOffset + PREAMBLE_STRIDE + aRelStartOffset;
         mAbsStopOffset  = aAbsStopPreambleOffset  + PREAMBLE_STRIDE + aRelStopOffset;
 
-        spdlog::debug("{}: aAbsStartPreambleOffset = {:08x}; Start Offset = {}",
+        spdlog::trace("{}: aAbsStartPreambleOffset = {:08x}; Start Offset = {}",
             __func__, aAbsStartPreambleOffset, aRelStartOffset);
-        spdlog::debug("{}: aAbsStopPreambleOffset  = {:08x}; Stop Offset  = {}",
+        spdlog::trace("{}: aAbsStopPreambleOffset  = {:08x}; Stop Offset  = {}",
             __func__, aAbsStopPreambleOffset, aRelStopOffset);
         spdlog::debug("{}: Adding 0x{:08x} -> 0x{:08x}", __func__, mAbsStartOffset, mAbsStopOffset);
 

--- a/src/Misc.cpp
+++ b/src/Misc.cpp
@@ -138,7 +138,7 @@ void Parser::readTitleBlockSymbol()
 
     for(size_t i = 0u; i < followingLen; ++i)
     {
-        readStructure();
+        spdlog::critical("VERIFYING Misc Structure0 is {}", NAMEOF_TYPE_RTTI(*readStructure().get())); // @todo push structure
     }
 
     if(!mDs.get().isEoF())

--- a/src/Streams/StreamNetBundleMapData.cpp
+++ b/src/Streams/StreamNetBundleMapData.cpp
@@ -60,10 +60,9 @@ void StreamNetBundleMapData::read(FileFormatVersion /* aVersion */)
         }
     }
 
-    // @todo use function
     if(!mDs.get().isEoF())
     {
-        throw std::runtime_error("Exptected EoF in NetBundleMapData");
+        throw std::runtime_error("Expected EoF but did not reach it!");
     }
 
     spdlog::debug(getClosingMsg(getMethodName(this, __func__), mDs.get().getCurrentOffset()));

--- a/src/Streams/StreamPackage.cpp
+++ b/src/Streams/StreamPackage.cpp
@@ -64,34 +64,33 @@ void StreamPackage::read(FileFormatVersion /* aVersion */)
 {
     spdlog::debug(getOpeningMsg(getMethodName(this, __func__), mDs.get().getCurrentOffset()));
 
-    const uint16_t sectionCount = mDs.get().readUint16();
+    const uint16_t lenProperties = mDs.get().readUint16();
 
-    spdlog::trace("sectionCount = {}", sectionCount);
+    spdlog::trace("lenProperties = {}", lenProperties);
 
-    for(size_t i = 0u; i < sectionCount; ++i)
+    for(size_t i = 0u; i < lenProperties; ++i)
     {
-        structures.push_back(readStructure());
+        properties.push_back(dynamic_pointer_cast<StructProperties>(readStructure()));
     }
 
-    // @todo maybe number of views (Convert, Normal) or number of units in the current view
-    const uint16_t len2 = mDs.get().readUint16();
+    const uint16_t lenPrimitives = mDs.get().readUint16();
 
-    spdlog::trace("len2 = {}", len2);
+    spdlog::trace("lenPrimitives = {}", lenPrimitives);
 
-    for(size_t i = 0u; i < len2; ++i)
+    for(size_t i = 0u; i < lenPrimitives; ++i)
     {
-        structures.push_back(readStructure());
+        primitives.push_back(dynamic_pointer_cast<StructPrimitives>(readStructure()));
     }
 
-    // @todo Probably only StructSymbolPinScalar
-    const uint16_t len3 = mDs.get().readUint16();
+    const uint16_t lenSymbolPins = mDs.get().readUint16();
 
-    spdlog::trace("len3 = {}", len3);
+    spdlog::trace("lenSymbolPins = {}", lenSymbolPins);
 
-    for(size_t i = 0u; i < len3; ++i)
+    for(size_t i = 0u; i < lenSymbolPins; ++i)
     {
-        structures.push_back(readStructure());
+        symbolPins.push_back(dynamic_pointer_cast<StructSymbolPin>(readStructure()));
 
+        // @todo This hack should probably be moved into StructSymbolPin
         const uint8_t early_out = mDs.get().peek(1)[0];
         spdlog::debug("early_out = {}", early_out);
 
@@ -103,28 +102,24 @@ void StreamPackage::read(FileFormatVersion /* aVersion */)
         }
     }
 
-    const uint16_t len4 = mDs.get().readUint16();
+    const uint16_t lenSymbolDisplayProps = mDs.get().readUint16();
 
-    spdlog::trace("len4 = {}", len4);
+    spdlog::trace("lenSymbolDisplayProps = {}", lenSymbolDisplayProps);
 
-    for(size_t i = 0u; i < len4; ++i)
+    for(size_t i = 0u; i < lenSymbolDisplayProps; ++i)
     {
-        structures.push_back(readStructure());
+        symbolDisplayProps.push_back(dynamic_pointer_cast<StructSymbolDisplayProp>(readStructure()));
     }
 
+    t0x1f = dynamic_pointer_cast<StructT0x1f>(readStructure());
+
+    const uint16_t lenPinIdxMappings = mDs.get().readUint16();
+
+    spdlog::trace("lenPinIdxMappings = {}", lenPinIdxMappings);
+
+    for(size_t i = 0u; i < lenPinIdxMappings; ++i)
     {
-        structures.push_back(readStructure());
-    }
-
-    // I guess its always a PinIdxMapping (or multiple)
-    // @todo should be the unit of the package
-    const uint16_t len5 = mDs.get().readUint16();
-
-    spdlog::trace("len5 = {}", len5);
-
-    for(size_t i = 0u; i < len5; ++i)
-    {
-        structures.push_back(readStructure());
+        pinIdxMappings.push_back(dynamic_pointer_cast<StructPinIdxMapping>(readStructure()));
     }
 
     if(!mDs.get().isEoF())

--- a/src/Streams/StreamPackage.hpp
+++ b/src/Streams/StreamPackage.hpp
@@ -12,13 +12,20 @@
 #include <nameof.hpp>
 
 #include "CommonBase.hpp"
+#include "Structures/StructPinIdxMapping.hpp"
+#include "Structures/StructPrimitives.hpp"
+#include "Structures/StructProperties.hpp"
+#include "Structures/StructSymbolDisplayProp.hpp"
+#include "Structures/StructSymbolPin.hpp"
+#include "Structures/StructT0x1f.hpp"
 
 
 class StreamPackage : public CommonBase
 {
 public:
 
-    StreamPackage(DataStream& aDs) : CommonBase{aDs}, structures{}
+    StreamPackage(DataStream& aDs) : CommonBase{aDs}, properties{}, primitives{},
+        symbolPins{}, symbolDisplayProps{}, t0x1f{}, pinIdxMappings{}
     { }
 
     std::string to_string() const override;
@@ -27,7 +34,14 @@ public:
 
     FileFormatVersion predictVersion();
 
-    std::vector<std::unique_ptr<CommonBase>> structures;
+    std::vector<std::unique_ptr<StructProperties>>        properties;
+    std::vector<std::unique_ptr<StructPrimitives>>        primitives;
+    std::vector<std::unique_ptr<StructSymbolPin>>         symbolPins;
+    std::vector<std::unique_ptr<StructSymbolDisplayProp>> symbolDisplayProps;
+
+    std::unique_ptr<StructT0x1f>                          t0x1f;
+
+    std::vector<std::unique_ptr<StructPinIdxMapping>>     pinIdxMappings;
 };
 
 
@@ -38,10 +52,37 @@ static std::string to_string(const StreamPackage& aObj)
 
     str += fmt::format("{}:\n", nameof::nameof_type<decltype(aObj)>());
 
-    str += fmt::format("{}structures:\n", indent(1));
-    for(size_t i = 0u; i < aObj.structures.size(); ++i)
+    str += fmt::format("{}properties:\n", indent(1));
+    for(size_t i = 0u; i < aObj.properties.size(); ++i)
     {
-        str += indent(fmt::format("[{}]: {}", i, aObj.structures[i]->to_string()), 2);
+        str += indent(fmt::format("[{}]: {}", i, aObj.properties[i]->to_string()), 2);
+    }
+
+    str += fmt::format("{}primitives:\n", indent(1));
+    for(size_t i = 0u; i < aObj.primitives.size(); ++i)
+    {
+        str += indent(fmt::format("[{}]: {}", i, aObj.primitives[i]->to_string()), 2);
+    }
+
+    str += fmt::format("{}symbolPins:\n", indent(1));
+    for(size_t i = 0u; i < aObj.symbolPins.size(); ++i)
+    {
+        str += indent(fmt::format("[{}]: {}", i, aObj.symbolPins[i]->to_string()), 2);
+    }
+
+    str += fmt::format("{}symbolDisplayProps:\n", indent(1));
+    for(size_t i = 0u; i < aObj.symbolDisplayProps.size(); ++i)
+    {
+        str += indent(fmt::format("[{}]: {}", i, aObj.symbolDisplayProps[i]->to_string()), 2);
+    }
+
+    str += fmt::format("{}t0x1f:\n", indent(1));
+    str += indent(aObj.t0x1f->to_string(), 2);
+
+    str += fmt::format("{}pinIdxMappings:\n", indent(1));
+    for(size_t i = 0u; i < aObj.pinIdxMappings.size(); ++i)
+    {
+        str += indent(fmt::format("[{}]: {}", i, aObj.pinIdxMappings[i]->to_string()), 2);
     }
 
     return str;

--- a/src/Streams/StreamPage.cpp
+++ b/src/Streams/StreamPage.cpp
@@ -27,6 +27,7 @@ void StreamPage::read(FileFormatVersion /* aVersion */)
 
     pageSettings.read();
 
+    // @todo Contains StructTitleBlock
     const uint16_t lenA = mDs.get().readUint16();
 
     spdlog::trace("lenA = {}", lenA);

--- a/src/Streams/StreamPage.hpp
+++ b/src/Streams/StreamPage.hpp
@@ -23,7 +23,8 @@ class StreamPage : public CommonBase
 {
 public:
 
-    StreamPage(DataStream& aDs) : CommonBase{aDs}, name{}, pageSize{}, pageSettings{mDs}
+    StreamPage(DataStream& aDs) : CommonBase{aDs}, name{}, pageSize{}, pageSettings{mDs},
+        t0x34s{}, t0x35s{}, wires{}, partInsts{}, ports{}
     { }
 
     std::string to_string() const override;

--- a/src/Streams/StreamSymbol.cpp
+++ b/src/Streams/StreamSymbol.cpp
@@ -12,7 +12,7 @@ void StreamSymbol::read(FileFormatVersion /* aVersion */)
 {
     spdlog::debug(getOpeningMsg(getMethodName(this, __func__), mDs.get().getCurrentOffset()));
 
-    structures.push_back(readStructure());
+    spdlog::critical("VERIFYING StreamSymbol Structure10 is {}", NAMEOF_TYPE_RTTI(*readStructure().get())); // @todo push structure
 
     mDs.get().printUnknownData(4, fmt::format("{}: 0", __func__));
 
@@ -24,13 +24,21 @@ void StreamSymbol::read(FileFormatVersion /* aVersion */)
     {
         spdlog::trace("i of geometryCount = {}", i);
 
+        // @todo This whole code sequence does not make much sense
+        //       Try if readStructure() works out of the box
         if(i > 0u)
         {
+            // @todo Check if the `if` statement is really necessary
+            //       auto_read_prefixes should be able to handle
+            //       a value of 0
             if(gFileFormatVersion == FileFormatVersion::B)
             {
-                auto_read_prefixes();
+                spdlog::critical("VERIFYING StreamSymbol Structure11 is {}", NAMEOF_TYPE_RTTI(auto_read_prefixes()));
             }
 
+            // @todo check if if works without the `if` statement
+            //       readPreamble should be able to skip it if it's
+            //       not present
             if(gFileFormatVersion >= FileFormatVersion::B)
             {
                 readPreamble();
@@ -49,22 +57,22 @@ void StreamSymbol::read(FileFormatVersion /* aVersion */)
     // @todo Trailing data could be SymbolBBox
     // readSymbolBBox(); // @todo push structure
 
-    const uint16_t len = mDs.get().readUint16();
+    const uint16_t lenSymbolPins = mDs.get().readUint16();
 
-    spdlog::trace("len = {}", len);
+    spdlog::trace("lenSymbolPins = {}", lenSymbolPins);
 
-    for(size_t i = 0u; i < len; ++i)
+    for(size_t i = 0u; i < lenSymbolPins; ++i)
     {
-        structures.push_back(readStructure());
+        symbolPins.push_back(dynamic_pointer_cast<StructSymbolPin>(readStructure()));
     }
 
-    const uint16_t len2 = mDs.get().readUint16();
+    const uint16_t lenSymbolDisplayProps = mDs.get().readUint16();
 
-    spdlog::trace("len2 = {}", len2);
+    spdlog::trace("lenSymbolDisplayProps = {}", lenSymbolDisplayProps);
 
-    for(size_t i = 0u; i < len2; ++i)
+    for(size_t i = 0u; i < lenSymbolDisplayProps; ++i)
     {
-        structures.push_back(readStructure());
+        symbolDisplayProps.push_back(dynamic_pointer_cast<StructSymbolDisplayProp>(readStructure()));
     }
 
     if(!mDs.get().isEoF())

--- a/src/Streams/StreamSymbol.hpp
+++ b/src/Streams/StreamSymbol.hpp
@@ -5,27 +5,30 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <vector>
 
 #include <fmt/core.h>
 #include <nameof.hpp>
 
 #include "CommonBase.hpp"
 #include "General.hpp"
+#include "Structures/StructSymbolDisplayProp.hpp"
+#include "Structures/StructSymbolPin.hpp"
 
 
 class StreamSymbol : public CommonBase
 {
 public:
 
-    StreamSymbol(DataStream& aDs) : CommonBase{aDs} , structures{}
+    StreamSymbol(DataStream& aDs) : CommonBase{aDs}, symbolPins{}, symbolDisplayProps{}
     { }
 
     std::string to_string() const override;
 
     void read(FileFormatVersion aVersion = FileFormatVersion::Unknown) override;
 
-
-    std::vector<std::unique_ptr<CommonBase>> structures;
+    std::vector<std::unique_ptr<StructSymbolPin>>         symbolPins;
+    std::vector<std::unique_ptr<StructSymbolDisplayProp>> symbolDisplayProps;
 };
 
 
@@ -36,10 +39,16 @@ static std::string to_string(const StreamSymbol& aObj)
 
     str += fmt::format("{}:\n", nameof::nameof_type<decltype(aObj)>());
 
-    str += fmt::format("{}structures:\n", indent(1));
-    for(size_t i = 0u; i < aObj.structures.size(); ++i)
+    str += fmt::format("{}symbolPins:\n", indent(1));
+    for(size_t i = 0u; i < aObj.symbolPins.size(); ++i)
     {
-        str += indent(fmt::format("[{}]: {}", i, aObj.structures[i]->to_string()), 2);
+        str += indent(fmt::format("[{}]: {}", i, aObj.symbolPins[i]->to_string()), 2);
+    }
+
+    str += fmt::format("{}symbolDisplayProps:\n", indent(1));
+    for(size_t i = 0u; i < aObj.symbolDisplayProps.size(); ++i)
+    {
+        str += indent(fmt::format("[{}]: {}", i, aObj.symbolDisplayProps[i]->to_string()), 2);
     }
 
     return str;

--- a/src/Structures/StructGraphicBoxInst.cpp
+++ b/src/Structures/StructGraphicBoxInst.cpp
@@ -39,7 +39,8 @@ void StructGraphicBoxInst::read(FileFormatVersion /* aVersion */)
     // @todo Only Rect as a shape would make sense here. Maybe this should be passed
     //       as a parameter to readSthInPages0 to check this condition. Further,
     //       parseStructure should always call readSthInPages0.
-    readStructure();
+    // readStructure();
+    spdlog::critical("VERIFYING StructGraphicBoxInst Structure0 is {}", NAMEOF_TYPE_RTTI(*readStructure().get())); // @todo push structure
 
     sanitizeThisFutureSize(thisFuture);
 

--- a/src/Structures/StructGraphicCommentTextInst.cpp
+++ b/src/Structures/StructGraphicCommentTextInst.cpp
@@ -20,7 +20,7 @@ void StructGraphicCommentTextInst::read(FileFormatVersion /* aVersion */)
 
     mDs.get().printUnknownData(34, std::string(__func__) + " - 0");
 
-    readStructure();
+    sthInPages0 = dynamic_pointer_cast<StructSthInPages0>(readStructure());
 
     mDs.get().printUnknownData(8, std::string(__func__) + " - 1");
 

--- a/src/Structures/StructGraphicCommentTextInst.hpp
+++ b/src/Structures/StructGraphicCommentTextInst.hpp
@@ -3,6 +3,7 @@
 
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <ostream>
 #include <string>
@@ -12,19 +13,21 @@
 
 #include "CommonBase.hpp"
 #include "General.hpp"
+#include "Structures/StructSthInPages0.hpp"
 
 
 class StructGraphicCommentTextInst : public CommonBase
 {
 public:
 
-    StructGraphicCommentTextInst(DataStream& aDs) : CommonBase{aDs}
+    StructGraphicCommentTextInst(DataStream& aDs) : CommonBase{aDs}, sthInPages0{}
     { }
 
     std::string to_string() const override;
 
     void read(FileFormatVersion aVersion = FileFormatVersion::Unknown) override;
 
+    std::unique_ptr<StructSthInPages0> sthInPages0;
 };
 
 
@@ -34,6 +37,9 @@ static std::string to_string(const StructGraphicCommentTextInst& aObj)
     std::string str;
 
     str += fmt::format("{}:\n", nameof::nameof_type<decltype(aObj)>());
+
+    str += fmt::format("{}sthInPages0:\n", indent(1));
+    str += indent(aObj.sthInPages0->to_string(), 2);
 
     return str;
 }

--- a/src/Structures/StructGraphicLineInst.cpp
+++ b/src/Structures/StructGraphicLineInst.cpp
@@ -20,7 +20,7 @@ void StructGraphicLineInst::read(FileFormatVersion /* aVersion */)
 
     mDs.get().printUnknownData(34, std::string(__func__) + " - 0");
 
-    readStructure();
+    sthInPages0 = dynamic_pointer_cast<StructSthInPages0>(readStructure());
 
     mDs.get().printUnknownData(16, std::string(__func__) + " - 1");
 

--- a/src/Structures/StructGraphicLineInst.hpp
+++ b/src/Structures/StructGraphicLineInst.hpp
@@ -3,6 +3,7 @@
 
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <ostream>
 #include <string>
@@ -12,19 +13,21 @@
 
 #include "CommonBase.hpp"
 #include "General.hpp"
+#include "Structures/StructSthInPages0.hpp"
 
 
 class StructGraphicLineInst : public CommonBase
 {
 public:
 
-    StructGraphicLineInst(DataStream& aDs) : CommonBase{aDs}
+    StructGraphicLineInst(DataStream& aDs) : CommonBase{aDs}, sthInPages0{}
     { }
 
     std::string to_string() const override;
 
     void read(FileFormatVersion aVersion = FileFormatVersion::Unknown) override;
 
+    std::unique_ptr<StructSthInPages0> sthInPages0;
 };
 
 
@@ -34,6 +37,9 @@ static std::string to_string(const StructGraphicLineInst& aObj)
     std::string str;
 
     str += fmt::format("{}:\n", nameof::nameof_type<decltype(aObj)>());
+
+    str += fmt::format("{}sthInPages0:\n", indent(1));
+    str += indent(aObj.sthInPages0->to_string(), 2);
 
     return str;
 }

--- a/src/Structures/StructPartInst.cpp
+++ b/src/Structures/StructPartInst.cpp
@@ -52,7 +52,8 @@ void StructPartInst::read(FileFormatVersion /* aVersion */)
 
     for(size_t i = 0u; i < len; ++i)
     {
-        readStructure(); // @todo push struct
+        spdlog::critical("VERIFYING StructPartInst Structure42 is {}", NAMEOF_TYPE_RTTI(*readStructure().get())); // @todo push structure
+        // readStructure(); // @todo push struct
     }
 
     mDs.get().printUnknownData(1, std::string(__func__) + " - 3");
@@ -69,7 +70,8 @@ void StructPartInst::read(FileFormatVersion /* aVersion */)
 
     for(size_t i = 0u; i < len2; ++i)
     {
-        readStructure(); // @todo push struct
+        spdlog::critical("VERIFYING StructPartInst Structure2 is {}", NAMEOF_TYPE_RTTI(*readStructure().get())); // @todo push structure
+        // readStructure(); // @todo push struct
     }
 
     const std::string sth1 = mDs.get().readStringLenZeroTerm(); // @todo needs verification

--- a/src/Structures/StructPort.cpp
+++ b/src/Structures/StructPort.cpp
@@ -26,14 +26,13 @@ void StructPort::read(FileFormatVersion /* aVersion */)
 
     mDs.get().printUnknownData(20, fmt::format("{}: 1", __func__));
 
-    const uint16_t len = mDs.get().readUint16();
+    const uint16_t lenSymbolDisplayProps = mDs.get().readUint16();
 
-    // @todo Should be display property
-    spdlog::trace("len = {}", len);
+    spdlog::trace("lenSymbolDisplayProps = {}", lenSymbolDisplayProps);
 
-    for(size_t i = 0; i < len; ++i)
+    for(size_t i = 0; i < lenSymbolDisplayProps; ++i)
     {
-        readStructure();
+        symbolDisplayProps.push_back(dynamic_pointer_cast<StructSymbolDisplayProp>(readStructure()));
     }
 
     mDs.get().printUnknownData(10, fmt::format("{}: 2", __func__));

--- a/src/Structures/StructPort.hpp
+++ b/src/Structures/StructPort.hpp
@@ -3,9 +3,11 @@
 
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <ostream>
 #include <string>
+#include <vector>
 
 #include <fmt/core.h>
 #include <nameof.hpp>
@@ -15,13 +17,14 @@
 #include "Enums/LineStyle.hpp"
 #include "Enums/LineWidth.hpp"
 #include "General.hpp"
+#include "Structures/StructSymbolDisplayProp.hpp"
 
 
 class StructPort : public CommonBase
 {
 public:
 
-    StructPort(DataStream& aDs) : CommonBase{aDs}, name{}
+    StructPort(DataStream& aDs) : CommonBase{aDs}, name{}, symbolDisplayProps{}
     { }
 
     std::string to_string() const override;
@@ -29,6 +32,8 @@ public:
     void read(FileFormatVersion aVersion = FileFormatVersion::Unknown) override;
 
     std::string name;
+
+    std::vector<std::unique_ptr<StructSymbolDisplayProp>> symbolDisplayProps;
 };
 
 
@@ -39,6 +44,12 @@ static std::string to_string(const StructPort& aObj)
 
     str += fmt::format("{}:\n", nameof::nameof_type<decltype(aObj)>());
     str += fmt::format("{}name = {}\n", indent(1), aObj.name);
+
+    str += fmt::format("{}symbolDisplayProps:\n", indent(1));
+    for(size_t i = 0u; i < aObj.symbolDisplayProps.size(); ++i)
+    {
+        str += indent(fmt::format("[{}]: {}", i, aObj.symbolDisplayProps[i]->to_string()), 2);
+    }
 
     return str;
 }

--- a/src/Structures/StructSymbolDisplayProp.cpp
+++ b/src/Structures/StructSymbolDisplayProp.cpp
@@ -56,7 +56,7 @@ void StructSymbolDisplayProp::read(FileFormatVersion /* aVersion */)
         const std::string msg = fmt::format("{}: textFontIdx is out of range! Expected {} < {}!",
             __func__, textFontIdx, gLibrary->library->textFonts.size());
 
-        spdlog::error(msg);
+        spdlog::warn(msg);
         // throw std::out_of_range(msg);
     }
 

--- a/src/Structures/StructSymbolPin.cpp
+++ b/src/Structures/StructSymbolPin.cpp
@@ -1,0 +1,31 @@
+#include <cstdint>
+#include <ostream>
+#include <string>
+
+#include <nameof.hpp>
+#include <spdlog/spdlog.h>
+
+#include "Enums/PortType.hpp"
+#include "General.hpp"
+#include "PinShape.hpp"
+#include "Structures/StructSymbolPin.hpp"
+
+
+// void StructSymbolPin::read(FileFormatVersion /* aVersion */)
+// {
+//     spdlog::debug(getOpeningMsg(getMethodName(this, __func__), mDs.get().getCurrentOffset()));
+
+//     auto_read_prefixes();
+
+//     readPreamble();
+
+//     const std::optional<FutureData> thisFuture = getFutureData();
+
+
+//     sanitizeThisFutureSize(thisFuture);
+
+//     readOptionalTrailingFuture();
+
+//     spdlog::debug(getClosingMsg(getMethodName(this, __func__), mDs.get().getCurrentOffset()));
+//     spdlog::trace(to_string());
+// }

--- a/src/Structures/StructSymbolPin.hpp
+++ b/src/Structures/StructSymbolPin.hpp
@@ -1,0 +1,36 @@
+#ifndef STRUCTSYMBOLPIN_HPP
+#define STRUCTSYMBOLPIN_HPP
+
+
+#include <cstdint>
+#include <ostream>
+#include <string>
+
+#include <fmt/core.h>
+#include <nameof.hpp>
+
+#include "CommonBase.hpp"
+#include "Enums/PortType.hpp"
+#include "PinShape.hpp"
+
+
+/*!
+ * @brief Pseudo structure that does not exist itself.
+          It's only provided to group structures that
+          are derived from it and extract common code
+          into it.
+ */
+class StructSymbolPin : public CommonBase
+{
+public:
+
+    StructSymbolPin(DataStream& aDs) : CommonBase{aDs}
+    { }
+
+    // std::string to_string() const override;
+
+    // void read(FileFormatVersion aVersion = FileFormatVersion::Unknown) override;
+};
+
+
+#endif // STRUCTSYMBOLPIN_HPP

--- a/src/Structures/StructSymbolPinBus.cpp
+++ b/src/Structures/StructSymbolPinBus.cpp
@@ -36,6 +36,8 @@ void StructSymbolPinBus::read(FileFormatVersion /* aVersion */)
 
     mDs.get().printUnknownData(6, std::string(__func__) + " - 1");
 
+    // @todo compare against SymbolPinScalar, maybe they have the same content
+
     sanitizeThisFutureSize(thisFuture);
 
     readOptionalTrailingFuture();

--- a/src/Structures/StructSymbolPinBus.hpp
+++ b/src/Structures/StructSymbolPinBus.hpp
@@ -9,17 +9,17 @@
 #include <fmt/core.h>
 #include <nameof.hpp>
 
-#include "CommonBase.hpp"
 #include "Enums/PortType.hpp"
 #include "PinShape.hpp"
+#include "Structures/StructSymbolPin.hpp"
 
 
 // @todo this looks exactly the same as SymbolPinScalar. Why is that?
-class StructSymbolPinBus : public CommonBase
+class StructSymbolPinBus : public StructSymbolPin
 {
 public:
 
-    StructSymbolPinBus(DataStream& aDs) : CommonBase{aDs}, name{}, startX{0}, startY{0},
+    StructSymbolPinBus(DataStream& aDs) : StructSymbolPin{aDs}, name{}, startX{0}, startY{0},
         hotptX{0}, hotptY{0}, pinShape{}, portType{PortType::Input}
     { }
 

--- a/src/Structures/StructSymbolPinScalar.cpp
+++ b/src/Structures/StructSymbolPinScalar.cpp
@@ -36,11 +36,15 @@ void StructSymbolPinScalar::read(FileFormatVersion /* aVersion */)
 
     mDs.get().printUnknownData(4, std::string(__func__) + " - 1");
 
-    const uint16_t struct_len = mDs.get().readUint16();
+    // @todo Type is StructSymbolDisplayProp
+    const uint16_t lenSymbolDisplayProps = mDs.get().readUint16();
 
-    for(size_t i = 0U; i < struct_len; ++i)
+    spdlog::trace("lenSymbolDisplayProps = {}", lenSymbolDisplayProps);
+
+    for(size_t i = 0U; i < lenSymbolDisplayProps; ++i)
     {
-        readStructure();
+        spdlog::critical("VERIFYING StructSymbolPinScalar Structure0 is {}", NAMEOF_TYPE_RTTI(*readStructure().get())); // @todo push structure
+        // readStructure();
     }
 
     sanitizeThisFutureSize(thisFuture);

--- a/src/Structures/StructSymbolPinScalar.hpp
+++ b/src/Structures/StructSymbolPinScalar.hpp
@@ -9,16 +9,16 @@
 #include <fmt/core.h>
 #include <nameof.hpp>
 
-#include "CommonBase.hpp"
 #include "Enums/PortType.hpp"
 #include "PinShape.hpp"
+#include "Structures/StructSymbolPin.hpp"
 
 
-class StructSymbolPinScalar : public CommonBase
+class StructSymbolPinScalar : public StructSymbolPin
 {
 public:
 
-    StructSymbolPinScalar(DataStream& aDs) : CommonBase{aDs}, name{},
+    StructSymbolPinScalar(DataStream& aDs) : StructSymbolPin{aDs}, name{},
         startX{0}, startY{0}, hotptX{0}, hotptY{0}, pinShape{}, portType{PortType::Input}
     { }
 

--- a/src/Structures/StructT0x10.cpp
+++ b/src/Structures/StructT0x10.cpp
@@ -44,7 +44,8 @@ void StructT0x10::read(FileFormatVersion /* aVersion */)
 
     for(size_t i = 0; i < len; ++i)
     {
-        readStructure();
+        spdlog::critical("VERIFYING StructT0x10 Structure0 is {}", NAMEOF_TYPE_RTTI(*readStructure().get())); // @todo push structure
+        // readStructure();
     }
 
     sanitizeThisFutureSize(thisFuture);

--- a/src/Structures/StructTitleBlock.cpp
+++ b/src/Structures/StructTitleBlock.cpp
@@ -27,13 +27,13 @@ void StructTitleBlock::read(FileFormatVersion /* aVersion */)
 
     mDs.get().printUnknownData(20, fmt::format("{}: 1", __func__));
 
-    const uint16_t len0 = mDs.get().readUint16();
+    const uint16_t lenSymbolDisplayProps = mDs.get().readUint16();
 
-    spdlog::trace("len0 = {}", len0);
+    spdlog::trace("lenSymbolDisplayProps = {}", lenSymbolDisplayProps);
 
-    for(size_t i = 0; i < len0; ++i)
+    for(size_t i = 0; i < lenSymbolDisplayProps; ++i)
     {
-        readStructure();
+        symbolDisplayProps.push_back(dynamic_pointer_cast<StructSymbolDisplayProp>(readStructure()));
     }
 
     mDs.get().printUnknownData(11, fmt::format("{}: 2", __func__));

--- a/src/Structures/StructTitleBlock.hpp
+++ b/src/Structures/StructTitleBlock.hpp
@@ -3,28 +3,32 @@
 
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <ostream>
 #include <string>
+#include <vector>
 
 #include <fmt/core.h>
 #include <nameof.hpp>
 
 #include "CommonBase.hpp"
 #include "General.hpp"
+#include "Structures/StructSymbolDisplayProp.hpp"
 
 
 class StructTitleBlock : public CommonBase
 {
 public:
 
-    StructTitleBlock(DataStream& aDs) : CommonBase{aDs}
+    StructTitleBlock(DataStream& aDs) : CommonBase{aDs}, symbolDisplayProps{}
     { }
 
     std::string to_string() const override;
 
     void read(FileFormatVersion aVersion = FileFormatVersion::Unknown) override;
 
+    std::vector<std::unique_ptr<StructSymbolDisplayProp>> symbolDisplayProps;
 };
 
 
@@ -34,6 +38,12 @@ static std::string to_string(const StructTitleBlock& aObj)
     std::string str;
 
     str += fmt::format("{}:\n", nameof::nameof_type<decltype(aObj)>());
+
+    str += fmt::format("{}symbolDisplayProps:\n", indent(1));
+    for(size_t i = 0u; i < aObj.symbolDisplayProps.size(); ++i)
+    {
+        str += indent(fmt::format("[{}]: {}", i, aObj.symbolDisplayProps[i]->to_string()), 2);
+    }
 
     return str;
 }


### PR DESCRIPTION
The intention is to keep the structures as close as possible to the file structure. Therefore specify in more detail what structures are present instead of just using a generic `std::vector<CommonBase*>`.