### PR TITLE
Disable Unit Tests by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Build Library, CLI Application and Tests
       run: |
-        cmake -B build -DCMAKE_BUILD_TYPE=Release -S . -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -S . -DENABLE_UNIT_TESTING=1 -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake
         cmake --build build -j $(nproc)
 
     - name: Run Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.8)
 
 project(OpenOrCadParser)
 
-option(ENABLE_UNIT_TESTING "Enable unit testing" ON)
+option(ENABLE_UNIT_TESTING "Enable unit testing" OFF)
 
 if(CMAKE_BUILD_TYPE STREQUAL "")
     message(STATUS "CMAKE_BUILD_TYPE not defined, 'Debug' will be used")

--- a/README.md
+++ b/README.md
@@ -39,8 +39,17 @@ The following two XSD files provide a good overview of the `XML` file structure,
 # Build
 
 ```bash
+# Install and set up vcpkg
+git clone https://github.com/microsoft/vcpkg.git
+./vcpkg/bootstrap-vcpkg.sh
+
 # Set path to vcpkg
-VCPKG_DIR=../vcpkg
+VCPKG_DIR=$(realpath ./vcpkg)
+
+# Get OpenOrCadParser
+git clone https://github.com/Werni2A/OpenOrCadParser.git
+
+cd OpenOrCadParser
 
 # Build
 cmake -B build -DCMAKE_BUILD_TYPE=Release -S . -DCMAKE_TOOLCHAIN_FILE=$VCPKG_DIR/scripts/buildsystems/vcpkg.cmake


### PR DESCRIPTION
Unit tests require that the tests were generated before, otherwise cmake fails with an ugly `No SOURCES given to target: test` error. Therefore disable them by default and enable them explicitly when necessary.

Fixes #101 